### PR TITLE
Fixed compiling issues on Godot

### DIFF
--- a/libs/anl/VM/vm.cpp
+++ b/libs/anl/VM/vm.cpp
@@ -1466,12 +1466,12 @@ void CNoiseExecutor::evaluateInstruction(InstructionListType &kernel, EvaluatedT
 		Q = v*(1.0-s*fract);
 		T = v*(1.0-s*(1.0-fract));
 
-		if (h>=0 and h<1) col=SRGBA(v,T,P,1);
-		else if (h>=1 and h<2) col=SRGBA(Q,v,P,a);
-		else if (h>=2 and h<3) col=SRGBA(P,v,T,a);
-		else if (h>=3 and h<4) col=SRGBA(P,Q,v,a);
-		else if (h>=4 and h<5) col=SRGBA(T,P,v,a);
-		else if (h>=5 and h<6) col=SRGBA(v,P,Q,a);
+		if (h>=0 && h<1) col=SRGBA(v,T,P,1);
+		else if (h>=1 && h<2) col=SRGBA(Q,v,P,a);
+		else if (h>=2 && h<3) col=SRGBA(P,v,T,a);
+		else if (h>=3 && h<4) col=SRGBA(P,Q,v,a);
+		else if (h>=4 && h<5) col=SRGBA(T,P,v,a);
+		else if (h>=5 && h<6) col=SRGBA(v,P,Q,a);
 		else col=SRGBA(0,0,0,a);
 
         cache[index].set(col);

--- a/noise.cpp
+++ b/noise.cpp
@@ -831,10 +831,10 @@ void AnlNoise::_bind_methods() {
 
     ClassDB::bind_method(D_METHOD("rotate", "src_index", "angle_index", "ax_index", "ay_index", "az_index"),&AnlNoise::rotate);
 
-    ClassDB::bind_method(D_METHOD("add_sequence", "base_index", "number", "stride"),AnlNoise::add_sequence, DEFVAL(1));
-    ClassDB::bind_method(D_METHOD("multiply_sequence", "base_index", "number", "stride"),AnlNoise::multiply_sequence, DEFVAL(1));
-    ClassDB::bind_method(D_METHOD("max_sequence", "base_index", "number", "stride"),AnlNoise::max_sequence, DEFVAL(1));
-    ClassDB::bind_method(D_METHOD("min_sequence", "base_index", "number", "stride"),AnlNoise::min_sequence, DEFVAL(1));
+    ClassDB::bind_method(D_METHOD("add_sequence", "base_index", "number", "stride"),&AnlNoise::add_sequence, DEFVAL(1));
+    ClassDB::bind_method(D_METHOD("multiply_sequence", "base_index", "number", "stride"),&AnlNoise::multiply_sequence, DEFVAL(1));
+    ClassDB::bind_method(D_METHOD("max_sequence", "base_index", "number", "stride"),&AnlNoise::max_sequence, DEFVAL(1));
+    ClassDB::bind_method(D_METHOD("min_sequence", "base_index", "number", "stride"),&AnlNoise::min_sequence, DEFVAL(1));
 
     ClassDB::bind_method(D_METHOD("mix", "low_index", "high_index", "control_index"),&AnlNoise::mix);
     ClassDB::bind_method(D_METHOD("select", "low_index", "high_index", "control_index", "threshold_index", "falloff_index"),&AnlNoise::select);


### PR DESCRIPTION
In noise.cpp, 4 of the functions were not referencing a pointer to an object, causing it to give out errors.
In vm.cpp, some of the if & else if statements from lines 1469-1474 utilized a boolean 'and' rather than '&&', causing some errors.

Afterwards, I was able to compile godot successfully following the build instructions on their website. [On Windows.](http://docs.godotengine.org/en/3.0/development/compiling/compiling_for_windows.html)