### PR TITLE
Remove module-specific configuration regarding C++11

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -12,12 +12,6 @@ thirdparty_dirs = [
 ]
 env_module.Append(CPPPATH=thirdparty_dirs)
 
-# Configure
-
-# Upstream uses C++11
-if (not env.msvc):
-    env_module.Append(CXXFLAGS=['-std=c++11'])
-
 # ANL sources
 env_thirdparty = env_module.Clone()
 for d in thirdparty_dirs:


### PR DESCRIPTION
Godot's entire codebase has shifted towards C++11 support:

godotengine/godot@5dae2ea

Postponing merging to remain potential compatibility with previous versions of Godot.