### PR TITLE
Fix bindings and doc generation issues

### DIFF
--- a/doc_classes/AccidentalNoise.xml
+++ b/doc_classes/AccidentalNoise.xml
@@ -89,9 +89,9 @@
 		<method name="billow">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
-			<argument index="1" name="interp_type" type="int" enum="anl.InterpolationTypes">
+			<argument index="1" name="interp_type" type="int" enum="AccidentalNoise.InterpolationTypes">
 			</argument>
 			<argument index="2" name="numoctaves" type="int">
 			</argument>
@@ -108,7 +108,7 @@
 		<method name="billow_layer">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
 			<argument index="1" name="interp_type_index" type="int">
 			</argument>
@@ -361,9 +361,9 @@
 		<method name="fbm">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
-			<argument index="1" name="interp_type" type="int" enum="anl.InterpolationTypes">
+			<argument index="1" name="interp_type" type="int" enum="AccidentalNoise.InterpolationTypes">
 			</argument>
 			<argument index="2" name="numoctaves" type="int">
 			</argument>
@@ -399,7 +399,7 @@
 		<method name="fractal_layer">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
 			<argument index="1" name="interp_type_index" type="int">
 			</argument>
@@ -636,7 +636,7 @@
 			</argument>
 			<description>
 				Generates gradient noise function as basis, with [enum InterpolationTypes] applied.
-				Notice that the first argument takes an index to a function. In order to set interpolation globally and not for each value, use [code]constant(InterpolationTypes.INTERP_QUINTIC)[/code], for instance.
+				Notice that the first argument takes an index to a function. In order to set interpolation globally and not for each value, use [constant INTERP_QUINTIC], for instance.
 			</description>
 		</method>
 		<method name="hex_bump">
@@ -808,7 +808,7 @@
 		<method name="ridged_layer">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
 			<argument index="1" name="interp_type_index" type="int">
 			</argument>
@@ -835,9 +835,9 @@
 		<method name="ridged_multifractal">
 			<return type="int">
 			</return>
-			<argument index="0" name="basis_type" type="int" enum="anl.BasisTypes">
+			<argument index="0" name="basis_type" type="int" enum="AccidentalNoise.BasisTypes">
 			</argument>
-			<argument index="1" name="interp_type" type="int" enum="anl.InterpolationTypes">
+			<argument index="1" name="interp_type" type="int" enum="AccidentalNoise.InterpolationTypes">
 			</argument>
 			<argument index="2" name="numoctaves" type="int">
 			</argument>
@@ -1019,7 +1019,7 @@
 			<argument index="0" name="seed_index" type="int">
 			</argument>
 			<description>
-				Generates simplex function as basis, with [enum InterpolationTypes.INTERP_QUINTIC] applied.
+				Generates simplex function as basis, with [constant INTERP_QUINTIC] applied.
 			</description>
 		</method>
 		<method name="sin">
@@ -1213,7 +1213,7 @@
 			</argument>
 			<description>
 				Generates value noise function as basis, with [enum InterpolationTypes] applied.
-				Notice that the first argument takes an index to a function. In order to set interpolation globally and not for each value, use [code]constant(InterpolationTypes.INTERP_QUINTIC)[/code], for instance.
+				Notice that the first argument takes an index to a function. In order to set interpolation globally and not for each value, use [constant INTERP_QUINTIC], for instance.
 			</description>
 		</method>
 		<method name="w">
@@ -1275,8 +1275,8 @@
 		<member name="last_function" type="int" setter="" getter="get_last_function" default="5">
 			Returns an index of the last noise function generated.
 		</member>
-		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="anl.EMappingModes" default="0">
-			Controls seamlessness of the noise function mapped to image. See [enum EMappingModes].
+		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="AccidentalNoise.MappingModes" default="0">
+			Controls seamlessness of the noise function mapped to image. See [enum MappingModes].
 		</member>
 		<member name="normalmap_normalized" type="bool" setter="set_normalmap_normalized" getter="is_normalmap_normalized" default="true">
 			If set to [code]true[/code], normalizes normal map output.
@@ -1334,28 +1334,28 @@
 		<constant name="BASIS_SIMPLEX" value="2" enum="BasisTypes">
 			Use simplex noise as basis for noise generation.
 		</constant>
-		<constant name="SEAMLESS_NONE" value="0" enum="EMappingModes">
+		<constant name="SEAMLESS_NONE" value="0" enum="MappingModes">
 			Do not generate seamless image.
 		</constant>
-		<constant name="SEAMLESS_X" value="1" enum="EMappingModes">
+		<constant name="SEAMLESS_X" value="1" enum="MappingModes">
 			Allows to generate a seamless image restricted to X coordinate, horizontally.
 		</constant>
-		<constant name="SEAMLESS_Y" value="2" enum="EMappingModes">
+		<constant name="SEAMLESS_Y" value="2" enum="MappingModes">
 			Allows to generate a seamless image restricted to Y coordinate, vertically.
 		</constant>
-		<constant name="SEAMLESS_Z" value="3" enum="EMappingModes">
+		<constant name="SEAMLESS_Z" value="3" enum="MappingModes">
 			Allows to generate a seamless image restricted to Z coordinate.
 		</constant>
-		<constant name="SEAMLESS_XY" value="4" enum="EMappingModes">
+		<constant name="SEAMLESS_XY" value="4" enum="MappingModes">
 			Allows to generate a seamless image restricted to XY plane, used to create seamless textures.
 		</constant>
-		<constant name="SEAMLESS_XZ" value="5" enum="EMappingModes">
+		<constant name="SEAMLESS_XZ" value="5" enum="MappingModes">
 			Allows to generate a seamless image restricted to XZ plane.
 		</constant>
-		<constant name="SEAMLESS_YZ" value="6" enum="EMappingModes">
+		<constant name="SEAMLESS_YZ" value="6" enum="MappingModes">
 			Allows to generate a seamless image restricted to YZ plane.
 		</constant>
-		<constant name="SEAMLESS_XYZ" value="7" enum="EMappingModes">
+		<constant name="SEAMLESS_XYZ" value="7" enum="MappingModes">
 			Allows to generate a seamless 3D image (not fully supported yet).
 		</constant>
 	</constants>

--- a/doc_classes/VisualAccidentalNoiseNodeFractalLayer.xml
+++ b/doc_classes/VisualAccidentalNoiseNodeFractalLayer.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="basis" type="int" setter="set_basis" getter="get_basis" enum="anl.BasisTypes" default="2">
+		<member name="basis" type="int" setter="set_basis" getter="get_basis" enum="AccidentalNoise.BasisTypes" default="2">
 		</member>
 		<member name="type" type="int" setter="set_type" getter="get_type" enum="VisualAccidentalNoiseNodeFractalLayer.LayerType" default="0">
 		</member>

--- a/doc_classes/VisualAccidentalNoiseNodeFractalVariant.xml
+++ b/doc_classes/VisualAccidentalNoiseNodeFractalVariant.xml
@@ -9,9 +9,9 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="basis" type="int" setter="set_basis" getter="get_basis" enum="anl.BasisTypes" default="2">
+		<member name="basis" type="int" setter="set_basis" getter="get_basis" enum="AccidentalNoise.BasisTypes" default="2">
 		</member>
-		<member name="interpolation" type="int" setter="set_interpolation" getter="get_interpolation" enum="anl.InterpolationTypes" default="3">
+		<member name="interpolation" type="int" setter="set_interpolation" getter="get_interpolation" enum="AccidentalNoise.InterpolationTypes" default="3">
 		</member>
 		<member name="type" type="int" setter="set_type" getter="get_type" enum="VisualAccidentalNoiseNodeFractalVariant.FractalType" default="0">
 		</member>

--- a/noise.cpp
+++ b/noise.cpp
@@ -8,7 +8,7 @@ AccidentalNoise::AccidentalNoise() :
 	function = 0;
 	prev_function = 0;
 
-	mode = anl::EMappingModes::SEAMLESS_NONE;
+	mode = SEAMLESS_NONE;
 	format = FORMAT_HEIGHTMAP;
 	ranges = AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
 
@@ -21,13 +21,13 @@ AccidentalNoise::AccidentalNoise() :
 	bumpmap_light = Vector3(1.0, 1.0, 1.0);
 }
 
-void AccidentalNoise::set_mode(anl::EMappingModes p_mode) {
+void AccidentalNoise::set_mode(MappingModes p_mode) {
 
 	mode = p_mode;
 	emit_changed();
 }
 
-anl::EMappingModes AccidentalNoise::get_mode() const {
+AccidentalNoise::MappingModes AccidentalNoise::get_mode() const {
 
 	return mode;
 }
@@ -675,7 +675,7 @@ Index AccidentalNoise::scale_offset(Index src, double scale, double offset) {
 	return scale_offset.getIndex();
 }
 
-Index AccidentalNoise::fractal_layer(anl::BasisTypes basis, Index interp_type,
+Index AccidentalNoise::fractal_layer(BasisTypes basis, Index interp_type,
 		double scale, double frequency, unsigned int seed, bool rot,
 		double angle, double ax, double ay, double az) {
 
@@ -686,7 +686,7 @@ Index AccidentalNoise::fractal_layer(anl::BasisTypes basis, Index interp_type,
 	return fractal_layer.getIndex();
 }
 
-Index AccidentalNoise::ridged_layer(anl::BasisTypes basis, Index interp_type,
+Index AccidentalNoise::ridged_layer(BasisTypes basis, Index interp_type,
 		double scale, double frequency, unsigned int seed, bool rot,
 		double angle, double ax, double ay, double az) {
 
@@ -697,7 +697,7 @@ Index AccidentalNoise::ridged_layer(anl::BasisTypes basis, Index interp_type,
 	return ridged_layer.getIndex();
 }
 
-Index AccidentalNoise::billow_layer(anl::BasisTypes basis, Index interp_type,
+Index AccidentalNoise::billow_layer(BasisTypes basis, Index interp_type,
 		double scale, double frequency, unsigned int seed, bool rot,
 		double angle, double ax, double ay, double az) {
 
@@ -708,7 +708,7 @@ Index AccidentalNoise::billow_layer(anl::BasisTypes basis, Index interp_type,
 	return billow_layer.getIndex();
 }
 
-Index AccidentalNoise::fbm(anl::BasisTypes basis, anl::InterpolationTypes interp,
+Index AccidentalNoise::fbm(BasisTypes basis, InterpolationTypes interp,
 		unsigned int numoctaves, double frequency, unsigned int seed, bool rot) {
 
 	auto fbm = kernel.simplefBm(
@@ -717,7 +717,7 @@ Index AccidentalNoise::fbm(anl::BasisTypes basis, anl::InterpolationTypes interp
 	return fbm.getIndex();
 }
 
-Index AccidentalNoise::ridged_multifractal(anl::BasisTypes basis, anl::InterpolationTypes interp,
+Index AccidentalNoise::ridged_multifractal(BasisTypes basis, InterpolationTypes interp,
 		unsigned int numoctaves, double frequency, unsigned int seed, bool rot) {
 
 	auto ridged_multifractal = kernel.simpleRidgedMultifractal(
@@ -726,7 +726,7 @@ Index AccidentalNoise::ridged_multifractal(anl::BasisTypes basis, anl::Interpola
 	return ridged_multifractal.getIndex();
 }
 
-Index AccidentalNoise::billow(anl::BasisTypes basis, anl::InterpolationTypes interp,
+Index AccidentalNoise::billow(BasisTypes basis, InterpolationTypes interp,
 		unsigned int numoctaves, double frequency, unsigned int seed, bool rot) {
 
 	auto billow = kernel.simpleBillow(
@@ -846,7 +846,7 @@ Ref<Image> AccidentalNoise::get_image(int p_width, int p_height) {
 Ref<Image> AccidentalNoise::get_seamless_image(int p_width, int p_height) {
 
 	// Returns seamless image regardless of mapping mode
-	return _map_to_image(p_width, p_height, function, anl::SEAMLESS_XY, format, ranges);
+	return _map_to_image(p_width, p_height, function, SEAMLESS_XY, format, ranges);
 }
 
 Ref<Texture> AccidentalNoise::get_texture(int p_width, int p_height) {
@@ -867,10 +867,10 @@ Vector<Ref<Image> > AccidentalNoise::get_image_3d(int p_width, int p_height, int
 Vector<Ref<Image> > AccidentalNoise::get_seamless_image_3d(int p_width, int p_height, int p_depth) {
 
 	// Returns seamless 3D image regardless of mapping mode
-	return _map_to_image_3d(p_width, p_height, p_depth, function, anl::SEAMLESS_XY, format, ranges);
+	return _map_to_image_3d(p_width, p_height, p_depth, function, SEAMLESS_XY, format, ranges);
 }
 
-Ref<Image> AccidentalNoise::_map_to_image(int p_width, int p_height, Index p_index, anl::EMappingModes p_mode, Format p_format, const AABB &p_ranges) {
+Ref<Image> AccidentalNoise::_map_to_image(int p_width, int p_height, Index p_index, MappingModes p_mode, Format p_format, const AABB &p_ranges) {
 
 	anl::SMappingRanges ranges(
 			p_ranges.position.x, p_ranges.position.x + p_ranges.size.x,
@@ -967,7 +967,7 @@ Ref<Image> AccidentalNoise::_map_to_image(int p_width, int p_height, Index p_ind
 	return noise;
 }
 
-Vector<Ref<Image> > AccidentalNoise::_map_to_image_3d(int p_width, int p_height, int p_depth, Index p_index, anl::EMappingModes p_mode, Format p_format, const AABB &p_ranges) {
+Vector<Ref<Image> > AccidentalNoise::_map_to_image_3d(int p_width, int p_height, int p_depth, Index p_index, MappingModes p_mode, Format p_format, const AABB &p_ranges) {
 
 	anl::SMappingRanges ranges(
 			p_ranges.position.x, p_ranges.position.x + p_ranges.size.x,
@@ -1286,9 +1286,6 @@ void AccidentalNoise::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_texture", "width", "height"), &AccidentalNoise::get_texture);
 
-	using namespace anl;
-	// Use namespace declaration to avoid having
-	// prepended namespace name in enum constants
 	BIND_ENUM_CONSTANT(INTERP_NONE);
 	BIND_ENUM_CONSTANT(INTERP_LINEAR);
 	BIND_ENUM_CONSTANT(INTERP_HERMITE);

--- a/noise.h
+++ b/noise.h
@@ -24,11 +24,42 @@ public:
 		FORMAT_BUMPMAP, // grayscale bumpmap
 		FORMAT_TEXTURE, // color, suitable for textures
 	};
+	enum InterpolationTypes
+	{
+		INTERP_NONE,
+		INTERP_LINEAR,
+		INTERP_HERMITE,
+		INTERP_QUINTIC
+	};
+	enum DistanceTypes
+	{
+		DISTANCE_EUCLID,
+		DISTANCE_MANHATTAN,
+		DISTANCE_LEASTAXIS,
+		DISTANCE_GREATESTAXIS
+	};
+	enum BasisTypes
+	{
+		BASIS_VALUE,
+		BASIS_GRADIENT,
+		BASIS_SIMPLEX
+	};
+	enum MappingModes
+	{
+		SEAMLESS_NONE,
+		SEAMLESS_X,
+		SEAMLESS_Y,
+		SEAMLESS_Z,
+		SEAMLESS_XY,
+		SEAMLESS_XZ,
+		SEAMLESS_YZ,
+		SEAMLESS_XYZ
+	};
 
 	AccidentalNoise();
 
-	void set_mode(anl::EMappingModes p_mode);
-	anl::EMappingModes get_mode() const;
+	void set_mode(MappingModes p_mode);
+	MappingModes get_mode() const;
 
 	void set_format(Format p_format);
 	Format get_format() const;
@@ -197,15 +228,15 @@ public:
 
 	// Layers
 	// ----------------------------------------------------------------------------------------
-	Index fractal_layer(anl::BasisTypes basis, Index interp_type,
+	Index fractal_layer(BasisTypes basis, Index interp_type,
 			double scale, double frequency, unsigned int seed, bool rot = true,
 			double angle = 0.5, double ax = 0.0, double ay = 0.0, double az = 1.0);
 
-	Index ridged_layer(anl::BasisTypes basis, Index interp_type,
+	Index ridged_layer(BasisTypes basis, Index interp_type,
 			double scale, double frequency, unsigned int seed, bool rot = true,
 			double angle = 0.5, double ax = 0.0, double ay = 0.0, double az = 1.0);
 
-	Index billow_layer(anl::BasisTypes basis, Index interp_type,
+	Index billow_layer(BasisTypes basis, Index interp_type,
 			double scale, double frequency, unsigned int seed, bool rot = true,
 			double angle = 0.5, double ax = 0.0, double ay = 0.0, double az = 1.0);
 
@@ -214,13 +245,13 @@ public:
 	Index fractal(Index seed, Index layer,
 			Index persistence, Index lacunarity, Index numoctaves, Index frequency);
 
-	Index fbm(anl::BasisTypes basis, anl::InterpolationTypes interp,
+	Index fbm(BasisTypes basis, InterpolationTypes interp,
 			unsigned int numoctaves, double frequency, unsigned int seed, bool rot = true);
 
-	Index ridged_multifractal(anl::BasisTypes basis, anl::InterpolationTypes interp,
+	Index ridged_multifractal(BasisTypes basis, InterpolationTypes interp,
 			unsigned int numoctaves, double frequency, unsigned int seed, bool rot = true);
 
-	Index billow(anl::BasisTypes basis, anl::InterpolationTypes interp,
+	Index billow(BasisTypes basis, InterpolationTypes interp,
 			unsigned int numoctaves, double frequency, unsigned int seed, bool rot = true);
 
 	// Variable
@@ -281,14 +312,14 @@ private:
 	anl::CNoiseExecutor vm;
 	anl::CExpressionBuilder eb;
 
-	Ref<Image> _map_to_image(int p_width, int p_height, Index p_index, anl::EMappingModes p_mode, Format p_format, const AABB &p_ranges);
-	Vector<Ref<Image> > _map_to_image_3d(int p_width, int p_height, int p_depth, Index p_index, anl::EMappingModes p_mode, Format p_format, const AABB &p_ranges);
+	Ref<Image> _map_to_image(int p_width, int p_height, Index p_index, MappingModes p_mode, Format p_format, const AABB &p_ranges);
+	Vector<Ref<Image> > _map_to_image_3d(int p_width, int p_height, int p_depth, Index p_index, MappingModes p_mode, Format p_format, const AABB &p_ranges);
 
 protected:
 	Index function;
 	Index prev_function;
 
-	anl::EMappingModes mode;
+	MappingModes mode;
 	Format format;
 	AABB ranges;
 	String expression;
@@ -302,10 +333,10 @@ protected:
 	Vector3 bumpmap_light;
 };
 
-VARIANT_ENUM_CAST(anl::InterpolationTypes);
-VARIANT_ENUM_CAST(anl::DistanceTypes);
-VARIANT_ENUM_CAST(anl::BasisTypes);
-VARIANT_ENUM_CAST(anl::EMappingModes);
+VARIANT_ENUM_CAST(AccidentalNoise::InterpolationTypes);
+VARIANT_ENUM_CAST(AccidentalNoise::DistanceTypes);
+VARIANT_ENUM_CAST(AccidentalNoise::BasisTypes);
+VARIANT_ENUM_CAST(AccidentalNoise::MappingModes);
 VARIANT_ENUM_CAST(AccidentalNoise::Format);
 
 #endif

--- a/plugins/visual_noise_component_editor_plugin.cpp
+++ b/plugins/visual_noise_component_editor_plugin.cpp
@@ -1598,7 +1598,7 @@ void VisualAccidentalNoiseNodePlugin::_bind_methods() {
 }
 
 class VisualAccidentalNoiseNodePluginDefaultEditor : public VBoxContainer {
-	GDCLASS(VisualAccidentalNoiseNodePluginDefaultEditor, VBoxContainer)
+	GDCLASS(VisualAccidentalNoiseNodePluginDefaultEditor, VBoxContainer);
 public:
 	void _property_changed(const String &prop, const Variant &p_value, const String &p_field, bool p_changing = false) {
 

--- a/plugins/visual_noise_component_editor_plugin.h
+++ b/plugins/visual_noise_component_editor_plugin.h
@@ -12,7 +12,7 @@
 
 class VisualAccidentalNoiseNodePlugin : public Reference {
 
-	GDCLASS(VisualAccidentalNoiseNodePlugin, Reference)
+	GDCLASS(VisualAccidentalNoiseNodePlugin, Reference);
 
 protected:
 	static void _bind_methods();
@@ -23,7 +23,7 @@ public:
 
 class VisualAccidentalNoiseNodePluginDefault : public VisualAccidentalNoiseNodePlugin {
 
-	GDCLASS(VisualAccidentalNoiseNodePluginDefault, VisualAccidentalNoiseNodePlugin)
+	GDCLASS(VisualAccidentalNoiseNodePluginDefault, VisualAccidentalNoiseNodePlugin);
 
 public:
 	virtual Control *create_editor(const Ref<VisualAccidentalNoiseNode> &p_node);
@@ -187,7 +187,7 @@ public:
 };
 
 class VisualAccidentalNoiseNodePortPreview : public Control {
-	GDCLASS(VisualAccidentalNoiseNodePortPreview, Control)
+	GDCLASS(VisualAccidentalNoiseNodePortPreview, Control);
 
 	Ref<VisualAccidentalNoise> noise;
 	Ref<Texture> preview_tex;

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -9,6 +9,7 @@ void register_anl_types() {
 
 	ClassDB::register_class<AccidentalNoise>();
 	ClassDB::register_class<VisualAccidentalNoise>();
+	ClassDB::register_virtual_class<VisualAccidentalNoiseNode>();
 
 	////// Component
 	ClassDB::register_class<VisualAccidentalNoiseNodeComponent>();

--- a/visual_noise.h
+++ b/visual_noise.h
@@ -81,7 +81,7 @@ private:
 };
 
 class VisualAccidentalNoiseNode : public Resource {
-	GDCLASS(VisualAccidentalNoiseNode, Resource)
+	GDCLASS(VisualAccidentalNoiseNode, Resource);
 
 	int port_preview;
 
@@ -139,7 +139,7 @@ public:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNode::PortType);
 
 class VisualAccidentalNoiseNodeComponent : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeComponent, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeComponent, VisualAccidentalNoiseNode);
 
 	friend class VisualAccidentalNoise;
 
@@ -250,7 +250,7 @@ public:
 };
 
 class VisualAccidentalNoiseNodeInput : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeInput, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeInput, VisualAccidentalNoiseNode);
 
 private:
 	String input_name;
@@ -284,7 +284,7 @@ public:
 };
 
 class VisualAccidentalNoiseNodeOutput : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeOutput, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeOutput, VisualAccidentalNoiseNode);
 
 public:
 	friend class VisualAccidentalNoise;

--- a/visual_noise_nodes.cpp
+++ b/visual_noise_nodes.cpp
@@ -617,7 +617,7 @@ void VisualAccidentalNoiseNodeValueBasis::_bind_methods() {
 
 VisualAccidentalNoiseNodeValueBasis::VisualAccidentalNoiseNodeValueBasis() {
 
-	set_input_port_default_value(0, anl::INTERP_QUINTIC);
+	set_input_port_default_value(0, AccidentalNoise::INTERP_QUINTIC);
 	set_input_port_default_value(1, 0);
 
 	interp = 0;
@@ -712,7 +712,7 @@ void VisualAccidentalNoiseNodeGradientBasis::_bind_methods() {
 
 VisualAccidentalNoiseNodeGradientBasis::VisualAccidentalNoiseNodeGradientBasis() {
 
-	set_input_port_default_value(0, anl::INTERP_QUINTIC);
+	set_input_port_default_value(0, AccidentalNoise::INTERP_QUINTIC);
 	set_input_port_default_value(1, 0);
 
 	interp = 0;
@@ -852,7 +852,7 @@ VisualAccidentalNoiseNodeCellularBasis::VisualAccidentalNoiseNodeCellularBasis()
 	set_input_port_default_value(6, 0);
 	set_input_port_default_value(7, 0);
 
-	set_input_port_default_value(8, anl::DISTANCE_EUCLID);
+	set_input_port_default_value(8, AccidentalNoise::DISTANCE_EUCLID);
 	set_input_port_default_value(9, 0);
 
 	f1 = f2 = f3 = f4 = 0;
@@ -2676,13 +2676,13 @@ VisualAccidentalNoiseNodeFractalLayer::LayerType VisualAccidentalNoiseNodeFracta
 	return type;
 }
 
-void VisualAccidentalNoiseNodeFractalLayer::set_basis(anl::BasisTypes p_basis) {
+void VisualAccidentalNoiseNodeFractalLayer::set_basis(AccidentalNoise::BasisTypes p_basis) {
 
 	basis = p_basis;
 	emit_changed();
 }
 
-anl::BasisTypes VisualAccidentalNoiseNodeFractalLayer::get_basis() const {
+AccidentalNoise::BasisTypes VisualAccidentalNoiseNodeFractalLayer::get_basis() const {
 
 	return basis;
 }
@@ -2733,9 +2733,9 @@ void VisualAccidentalNoiseNodeFractalLayer::_bind_methods() {
 VisualAccidentalNoiseNodeFractalLayer::VisualAccidentalNoiseNodeFractalLayer() {
 
 	type = LAYER_FRACTAL;
-	basis = anl::BASIS_SIMPLEX;
+	basis = AccidentalNoise::BASIS_SIMPLEX;
 
-	set_input_port_default_value(0, anl::INTERP_QUINTIC);
+	set_input_port_default_value(0, AccidentalNoise::INTERP_QUINTIC);
 	set_input_port_default_value(1, 1.0);
 	set_input_port_default_value(2, 1.0);
 	set_input_port_default_value(3, 0);
@@ -2926,24 +2926,24 @@ VisualAccidentalNoiseNodeFractalVariant::FractalType VisualAccidentalNoiseNodeFr
 	return type;
 }
 
-void VisualAccidentalNoiseNodeFractalVariant::set_basis(anl::BasisTypes p_basis) {
+void VisualAccidentalNoiseNodeFractalVariant::set_basis(AccidentalNoise::BasisTypes p_basis) {
 
 	basis = p_basis;
 	emit_changed();
 }
 
-anl::BasisTypes VisualAccidentalNoiseNodeFractalVariant::get_basis() const {
+AccidentalNoise::BasisTypes VisualAccidentalNoiseNodeFractalVariant::get_basis() const {
 
 	return basis;
 }
 
-void VisualAccidentalNoiseNodeFractalVariant::set_interpolation(anl::InterpolationTypes p_interpolation) {
+void VisualAccidentalNoiseNodeFractalVariant::set_interpolation(AccidentalNoise::InterpolationTypes p_interpolation) {
 
 	interpolation = p_interpolation;
 	emit_changed();
 }
 
-anl::InterpolationTypes VisualAccidentalNoiseNodeFractalVariant::get_interpolation() const {
+AccidentalNoise::InterpolationTypes VisualAccidentalNoiseNodeFractalVariant::get_interpolation() const {
 
 	return interpolation;
 }
@@ -2999,8 +2999,8 @@ void VisualAccidentalNoiseNodeFractalVariant::_bind_methods() {
 VisualAccidentalNoiseNodeFractalVariant::VisualAccidentalNoiseNodeFractalVariant() {
 
 	type = TYPE_FBM;
-	basis = anl::BASIS_SIMPLEX;
-	interpolation = anl::INTERP_QUINTIC;
+	basis = AccidentalNoise::BASIS_SIMPLEX;
+	interpolation = AccidentalNoise::INTERP_QUINTIC;
 
 	set_input_port_default_value(0, 1);
 	set_input_port_default_value(1, 1.0);

--- a/visual_noise_nodes.h
+++ b/visual_noise_nodes.h
@@ -4,7 +4,7 @@
 #include "visual_noise.h"
 
 class VisualAccidentalNoiseNodeScalar : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeScalar, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeScalar, VisualAccidentalNoiseNode);
 
 public:
 	enum ScalarType {
@@ -51,7 +51,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeScalar::ScalarType);
 
 class VisualAccidentalNoiseNodeSeed : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSeed, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSeed, VisualAccidentalNoiseNode);
 
 public:
 	void set_seed(unsigned int p_value);
@@ -82,7 +82,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeSeeder : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSeeder, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSeeder, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -110,7 +110,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeScalarOp : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeScalarOp, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeScalarOp, VisualAccidentalNoiseNode);
 
 public:
 	enum Operator {
@@ -158,7 +158,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeScalarOp::Operator);
 
 class VisualAccidentalNoiseNodeScalarFunc : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeScalarFunc, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeScalarFunc, VisualAccidentalNoiseNode);
 
 public:
 	enum Function {
@@ -205,7 +205,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeScalarFunc::Function);
 
 class VisualAccidentalNoiseNodeValueBasis : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeValueBasis, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeValueBasis, VisualAccidentalNoiseNode);
 
 public:
 	void set_interpolation(Index p_idx);
@@ -240,7 +240,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeGradientBasis : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeGradientBasis, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeGradientBasis, VisualAccidentalNoiseNode);
 
 public:
 	void set_interpolation(Index p_idx);
@@ -275,7 +275,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeCellularBasis : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeCellularBasis, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeCellularBasis, VisualAccidentalNoiseNode);
 
 public:
 	void set_distance(Index p_idx);
@@ -311,7 +311,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeSimplexBasis : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSimplexBasis, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSimplexBasis, VisualAccidentalNoiseNode);
 
 public:
 	void set_seed(Index p_idx);
@@ -342,7 +342,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeExpression : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeExpression, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeExpression, VisualAccidentalNoiseNode);
 
 public:
 	void set_expression(const String &p_expression);
@@ -375,7 +375,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeTranslate : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeTranslate, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeTranslate, VisualAccidentalNoiseNode);
 
 public:
 	void set_axis(Axis::AxisType p_type);
@@ -411,7 +411,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeScale : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeScale, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeScale, VisualAccidentalNoiseNode);
 
 public:
 	void set_axis(Axis::AxisType p_type);
@@ -447,7 +447,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeRotate : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeRotate, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeRotate, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -475,7 +475,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeClamp : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeClamp, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeClamp, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -503,7 +503,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeMix : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeMix, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeMix, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -531,7 +531,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeSelect : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSelect, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSelect, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -561,7 +561,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeTiers : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeTiers, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeTiers, VisualAccidentalNoiseNode);
 
 public:
 	enum Smoothness {
@@ -604,7 +604,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeTiers::Smoothness);
 
 class VisualAccidentalNoiseNodeGradient : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeGradient, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeGradient, VisualAccidentalNoiseNode);
 
 public:
 	void set_axis(Axis::AxisType p_type);
@@ -635,7 +635,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeDerivative : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeDerivative, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeDerivative, VisualAccidentalNoiseNode);
 
 public:
 	void set_axis(Axis::AxisType p_type);
@@ -671,7 +671,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeRadial : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeRadial, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeRadial, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -693,7 +693,7 @@ protected:
 };
 
 class VisualAccidentalNoiseNodeRandomize : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeRandomize, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeRandomize, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -721,7 +721,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeStep : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeStep, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeStep, VisualAccidentalNoiseNode);
 
 public:
 	enum StepType {
@@ -767,7 +767,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeStep::StepType);
 
 class VisualAccidentalNoiseNodeCurveSection : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeCurveSection, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeCurveSection, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -796,7 +796,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeHex : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeHex, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeHex, VisualAccidentalNoiseNode);
 
 public:
 	enum HexType {
@@ -838,7 +838,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeHex::HexType);
 
 class VisualAccidentalNoiseNodeColor : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeColor, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeColor, VisualAccidentalNoiseNode);
 
 public:
 	void set_color(const Color &p_color);
@@ -869,7 +869,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeColorCombine : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeColorCombine, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeColorCombine, VisualAccidentalNoiseNode);
 
 public:
 	enum CombineMode {
@@ -911,7 +911,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeColorCombine::CombineMode);
 
 class VisualAccidentalNoiseNodeScaleOffset : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeScaleOffset, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeScaleOffset, VisualAccidentalNoiseNode);
 
 public:
 	void set_scale(double p_value);
@@ -950,7 +950,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeFractalLayer : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeFractalLayer, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeFractalLayer, VisualAccidentalNoiseNode);
 
 public:
 	enum LayerType {
@@ -1005,7 +1005,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeFractalLayer::LayerType);
 
 class VisualAccidentalNoiseNodeFractal : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeFractal, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeFractal, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -1037,7 +1037,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeFractalVariant : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeFractalVariant, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeFractalVariant, VisualAccidentalNoiseNode);
 
 public:
 	enum FractalType {
@@ -1091,7 +1091,7 @@ private:
 VARIANT_ENUM_CAST(VisualAccidentalNoiseNodeFractalVariant::FractalType);
 
 class VisualAccidentalNoiseNodeSetVar : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSetVar, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSetVar, VisualAccidentalNoiseNode);
 
 public:
 	void set_var(const String &p_var);
@@ -1128,7 +1128,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeGetVar : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeGetVar, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeGetVar, VisualAccidentalNoiseNode);
 
 public:
 	void set_var(const String &p_var);
@@ -1157,7 +1157,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeReroute : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeReroute, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeReroute, VisualAccidentalNoiseNode);
 
 public:
 	virtual String get_caption() const;
@@ -1184,7 +1184,7 @@ private:
 };
 
 class VisualAccidentalNoiseNodeSequence : public VisualAccidentalNoiseNode {
-	GDCLASS(VisualAccidentalNoiseNodeSequence, VisualAccidentalNoiseNode)
+	GDCLASS(VisualAccidentalNoiseNodeSequence, VisualAccidentalNoiseNode);
 
 public:
 	enum Operator {

--- a/visual_noise_nodes.h
+++ b/visual_noise_nodes.h
@@ -962,8 +962,8 @@ public:
 	void set_type(LayerType p_type);
 	LayerType get_type() const;
 
-	void set_basis(anl::BasisTypes p_basis);
-	anl::BasisTypes get_basis() const;
+	void set_basis(AccidentalNoise::BasisTypes p_basis);
+	AccidentalNoise::BasisTypes get_basis() const;
 
 public:
 	virtual String get_caption() const;
@@ -989,7 +989,7 @@ protected:
 
 private:
 	LayerType type;
-	anl::BasisTypes basis;
+	AccidentalNoise::BasisTypes basis;
 
 	Index interp;
 	double scale;
@@ -1049,11 +1049,11 @@ public:
 	void set_type(FractalType p_type);
 	FractalType get_type() const;
 
-	void set_basis(anl::BasisTypes p_basis);
-	anl::BasisTypes get_basis() const;
+	void set_basis(AccidentalNoise::BasisTypes p_basis);
+	AccidentalNoise::BasisTypes get_basis() const;
 
-	void set_interpolation(anl::InterpolationTypes p_interpolation);
-	anl::InterpolationTypes get_interpolation() const;
+	void set_interpolation(AccidentalNoise::InterpolationTypes p_interpolation);
+	AccidentalNoise::InterpolationTypes get_interpolation() const;
 
 public:
 	virtual String get_caption() const;
@@ -1079,8 +1079,8 @@ protected:
 
 private:
 	FractalType type;
-	anl::BasisTypes basis;
-	anl::InterpolationTypes interpolation;
+	AccidentalNoise::BasisTypes basis;
+	AccidentalNoise::InterpolationTypes interpolation;
 
 	unsigned int numoctaves;
 	double frequency = 1.0;


### PR DESCRIPTION
Closes #21.

There was a missing `VisualAccidentalNoiseNode` class which wasn't exposed as virtual, so likely binding generator fails.

Another issue is that enum types were reused from within `anl` namespace directly so this can also cause errors I think.